### PR TITLE
Add support for pdf2htmlex `--split-page` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Kristin.convert('document.pdf', 'document.html', { first_page: 2, last_page: 4, 
 # zoom - zoom ratio. Default: 1.0
 # fit_width - fit width (pixels). Example: fit_width: 1024 
 # fit_height - fit height (pixels). Example: fit_height: 1024   
+# split_pages - if true, output is split into pages. Example: split_pages: true
 
 ```
 

--- a/lib/kristin.rb
+++ b/lib/kristin.rb
@@ -35,6 +35,7 @@ module Kristin
       opts.push("--zoom #{@options[:zoom]}") if @options[:zoom]
       opts.push("--fit-width #{@options[:fit_width]}") if @options[:fit_width]
       opts.push("--fit-height #{@options[:fit_height]}") if @options[:fit_height]
+      opts.push("--split-pages 1") if @options[:split_pages]
       opts.join(" ")
     end
 


### PR DESCRIPTION
This PR adds support for directing pdf2htmlex to write its output to multiple pages.

On the Ruby side you can now provide a `split_pages` parameter:

```
Kristin.convert("someFile.pdf", "someFile.html", { split_pages: true })
```

This is passed to pdf2htmlex as this command line option:

```
--split-pages 1
```

...as discussed in the [pdf2htmlex docs](https://github.com/coolwanglu/pdf2htmlEX/wiki/Command-Line-Options)


