### PR TITLE
add `data_dir` and `split_pages` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Kristin.convert('document.pdf', 'document.html', { first_page: 2, last_page: 4, 
 # zoom - zoom ratio. Default: 1.0
 # fit_width - fit width (pixels). Example: fit_width: 1024 
 # fit_height - fit height (pixels). Example: fit_height: 1024   
+# split_pages - if true, output is split into pages. Example: split_pages: true
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Kristin.convert('document.pdf', 'document.html', { first_page: 2, last_page: 4, 
 # fit_width - fit width (pixels). Example: fit_width: 1024 
 # fit_height - fit height (pixels). Example: fit_height: 1024   
 # split_pages - if true, output is split into pages. Example: split_pages: true
+# data_dir - if provided, overrides the directory in which pdf2htmlex looks for assets (js, html,css) for page generation. Example: data_dir: /Users/alphonse/pdf/templates
 
 ```
 

--- a/lib/kristin.rb
+++ b/lib/kristin.rb
@@ -35,6 +35,7 @@ module Kristin
       opts.push("--zoom #{@options[:zoom]}") if @options[:zoom]
       opts.push("--fit-width #{@options[:fit_width]}") if @options[:fit_width]
       opts.push("--fit-height #{@options[:fit_height]}") if @options[:fit_height]
+      opts.push("--split-pages 1") if @options[:split_pages]
       opts.join(" ")
     end
 

--- a/lib/kristin.rb
+++ b/lib/kristin.rb
@@ -36,6 +36,7 @@ module Kristin
       opts.push("--fit-width #{@options[:fit_width]}") if @options[:fit_width]
       opts.push("--fit-height #{@options[:fit_height]}") if @options[:fit_height]
       opts.push("--split-pages 1") if @options[:split_pages]
+      opts.push("--data-dir #{@options[:data_dir]}") if @options[:data_dir]
       opts.join(" ")
     end
 


### PR DESCRIPTION
Add support for `split_pages` and `data_dir`. 

#### split_pages

Generates individual HTML files for each page in a PDF:

```
Kristin.convert("somePdf.pdf", "someHtml.html", { split_pages: true })
```

which is converted to this command line flag:

```
--split-pages 1
```

#### data_dir

Specifies the location of the directory in which CSS and JS can be found for the viewer.

```
Kristin.convert("somePdf.pdf", "someHtml.html", { split_pages: true, data_dir: "/Users/foo/pdf" })
```

This is converted to the following command line flag:

```
--data-dir <directory>
```

