### PR TITLE
Update options and @target 

### DIFF
--- a/kristin.gemspec
+++ b/kristin.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pry"
 end

--- a/kristin.gemspec
+++ b/kristin.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.add_dependency "spoon"
-  
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "pry"
 end

--- a/lib/kristin.rb
+++ b/lib/kristin.rb
@@ -28,12 +28,12 @@ module Kristin
     def process_options
       opts = []
 
-      if @target && (@target == File.absolute_path(@target)) && @options[:dest_dir].nil?
+      if @target && (@target == File.absolute_path(@target))
         abs_path = File.absolute_path(@target)
         @target = File.basename(@target)
         @options[:dest_dir] == File.absolute_path(abs_path.gsub(@target,''))
       end
-      
+
       opts.push("--process-outline 0") if @options[:process_outline] == false
       opts.push("--first-page #{@options[:first_page]}") if @options[:first_page]
       opts.push("--last-page #{@options[:last_page]}") if @options[:last_page]

--- a/lib/kristin.rb
+++ b/lib/kristin.rb
@@ -31,7 +31,7 @@ module Kristin
       if @target && (@target == File.absolute_path(@target))
         abs_path = File.absolute_path(@target)
         @target = File.basename(@target)
-        @options[:dest_dir] == File.absolute_path(abs_path.gsub(@target,''))
+        @options[:dest_dir] = File.absolute_path(abs_path.gsub(@target,''))
       end
 
       opts.push("--process-outline 0") if @options[:process_outline] == false

--- a/lib/kristin.rb
+++ b/lib/kristin.rb
@@ -18,7 +18,7 @@ module Kristin
       args = [pdf2htmlex_command, opts, src, @target].flatten
       pid = Spoon.spawnp(*args)
       Process.waitpid(pid)
-      
+
       ## TODO: Grab error message from pdf2htmlex and raise a better error
       raise IOError, "Could not convert #{src}" if $?.exitstatus != 0
     end
@@ -27,6 +27,13 @@ module Kristin
 
     def process_options
       opts = []
+
+      if @target && (@target == File.absolute_path(@target)) && @options[:dest_dir].nil?
+        abs_path = File.absolute_path(@target)
+        @target = File.basename(@target)
+        @options[:dest_dir] == File.absolute_path(abs_path.gsub(@target,''))
+      end
+      
       opts.push("--process-outline 0") if @options[:process_outline] == false
       opts.push("--first-page #{@options[:first_page]}") if @options[:first_page]
       opts.push("--last-page #{@options[:last_page]}") if @options[:last_page]
@@ -37,6 +44,8 @@ module Kristin
       opts.push("--fit-height #{@options[:fit_height]}") if @options[:fit_height]
       opts.push("--split-pages 1") if @options[:split_pages]
       opts.push("--data-dir #{@options[:data_dir]}") if @options[:data_dir]
+      opts.push("--dest-dir #{@options[:dest_dir]}") if @options[:dest_dir]
+      opts.push("--tmp-dir #{@options[:tmp_dir]}") if @options[:tmp_dir]
       opts.join(" ")
     end
 
@@ -81,7 +90,7 @@ module Kristin
       is_http = URI(source).scheme == "http"
       is_https = URI(source).scheme == "https"
       raise IOError, "Source (#{source}) is neither a file nor an URL." unless is_file || is_http || is_https
-    
+
       is_file ? source : download_file(source)
     end
   end

--- a/spec/kristin_spec.rb
+++ b/spec/kristin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
+require 'pry'
+describe Kristin do
 
-describe Kristin do 
-  
   before(:all) do
     @one_page_pdf = file_path("one.pdf")
     @multi_page_pdf = file_path("multi.pdf")


### PR DESCRIPTION
## Agenda 
`pdf2htmlEX` uses relative paths for `@target` in conjunctions with `--dest-dir` flag

## Fix 
- [X] add `--dest-dir` and `--tmp-dir` flags to converter
- [X] map `@target` abs paths to relative paths and implicitly set `--dest-dir`
